### PR TITLE
Split CI/CD workflow and use matrix tests in CD

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -4,18 +4,27 @@
 name: "Publish on PyPI"
 
 on:
-  tags:
-    - "v*.*.*"
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version:
+          - 3.5
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.5'
+        python-version: ${{matrix.python_version}}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -25,12 +34,20 @@ jobs:
    
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version:
+          - 3.5
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.5'
+        python-version: ${{matrix.python_version}}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -41,12 +58,20 @@ jobs:
         
   security:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version:
+          - 3.5
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.5'
+        python-version: ${{matrix.python_version}}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -1,9 +1,11 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: "CI/CD"
+name: "Publish on PyPI"
 
-on: [push, pull_request]
+on:
+  tags:
+    - "v*.*.*"
 
 jobs:
   test:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,58 @@
+
+name: "Continuous Integration"
+
+on:
+    push:
+        branches:
+            - master
+            - integration
+    pull_request:
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.5'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest -r requirements/production
+    - name: Run non-regression test sets
+      run: python -m pytest -s tests/
+   
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.5'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 -r requirements/production
+    - name: Run linting script to determine syntax errors
+      run: |
+        flake8 music_browser/
+        
+  security:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.5'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install bandit -r requirements/production
+    - name: Run security issues checks
+      run: |
+        bandit -r music_browser/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.0.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 setuptools.setup(
     name="music-browser",
     description="Music search engine for CrossPlay web service.",
-    version="0.0.2",
+    version="0.0.3",
     packages=setuptools.find_packages(),
     install_requires=["marshmallow", "requests"],
 )


### PR DESCRIPTION
* On random branches, quick tests will be run on push / pull_requests, with a single python version.

* On version tags (releases), test with full matrix of python supported versions are ran before deployment.